### PR TITLE
provisioner/ansible: more configuration options

### DIFF
--- a/provisioner/ansible-local/provisioner.go
+++ b/provisioner/ansible-local/provisioner.go
@@ -24,6 +24,12 @@ type Config struct {
 	// An array of local paths of roles to upload.
 	RolePaths []string `mapstructure:"role_paths"`
 
+	// Path to group_vars directory
+	GroupVars string `mapstructure:"group_vars"`
+
+	// Path to host_vars directory
+	HostVars string `mapstructure:"host_vars"`
+
 	// The directory where files will be uploaded. Packer requires write
 	// permissions in this directory.
 	StagingDir string `mapstructure:"staging_directory"`
@@ -69,6 +75,8 @@ func (p *Provisioner) Prepare(raws ...interface{}) error {
 		"playbook_file": &p.config.PlaybookFile,
 		"staging_dir":   &p.config.StagingDir,
 		"command":       &p.config.Command,
+		"group_vars":    &p.config.GroupVars,
+		"host_vars":     &p.config.HostVars,
 	}
 
 	for n, ptr := range templates {
@@ -113,6 +121,20 @@ func (p *Provisioner) Prepare(raws ...interface{}) error {
 			errs = packer.MultiErrorAppend(errs, err)
 		}
 	}
+
+	// Check that the group_vars directory exists, if configured
+	if len(p.config.GroupVars) > 0 {
+		if err := validateDirConfig(p.config.GroupVars, "group_vars"); err != nil {
+			errs = packer.MultiErrorAppend(errs, err)
+		}
+	}
+
+	// Check that the host_vars directory exists, if configured
+	if len(p.config.HostVars) > 0 {
+		if err := validateDirConfig(p.config.HostVars, "host_vars"); err != nil {
+			errs = packer.MultiErrorAppend(errs, err)
+		}
+	}
 	if errs != nil && len(errs.Errors) > 0 {
 		return errs
 	}
@@ -132,6 +154,26 @@ func (p *Provisioner) Provision(ui packer.Ui, comm packer.Communicator) error {
 	dst := filepath.Join(p.config.StagingDir, filepath.Base(src))
 	if err := p.uploadFile(ui, comm, dst, src); err != nil {
 		return fmt.Errorf("Error uploading main playbook: %s", err)
+	}
+
+	// Upload group_vars
+	if len(p.config.GroupVars) > 0 {
+		ui.Message("Uploading group_vars directory...")
+		src := p.config.GroupVars
+		dst := filepath.Join(p.config.StagingDir, "group_vars")
+		if err := p.uploadDir(ui, comm, dst, src); err != nil {
+			return fmt.Errorf("Error uploading group_vars directory: %s", err)
+		}
+	}
+
+	// Upload host_vars
+	if len(p.config.HostVars) > 0 {
+		ui.Message("Uploading host_vars directory...")
+		src := p.config.HostVars
+		dst := filepath.Join(p.config.StagingDir, "host_vars")
+		if err := p.uploadDir(ui, comm, dst, src); err != nil {
+			return fmt.Errorf("Error uploading host_vars directory: %s", err)
+		}
 	}
 
 	if len(p.config.RolePaths) > 0 {

--- a/provisioner/ansible-local/provisioner_test.go
+++ b/provisioner/ansible-local/provisioner_test.go
@@ -120,4 +120,28 @@ func TestProvisionerPrepare_Dirs(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
+
+	config["group_vars"] = playbook_file.Name()
+	err = p.Prepare(config)
+	if err == nil {
+		t.Fatalf("should error if group_vars path is not a dir")
+	}
+
+	config["group_vars"] = os.TempDir()
+	err = p.Prepare(config)
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	config["host_vars"] = playbook_file.Name()
+	err = p.Prepare(config)
+	if err == nil {
+		t.Fatalf("should error if host_vars path is not a dir")
+	}
+
+	config["host_vars"] = os.TempDir()
+	err = p.Prepare(config)
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
 }

--- a/website/source/docs/provisioners/ansible-local.html.markdown
+++ b/website/source/docs/provisioners/ansible-local.html.markdown
@@ -34,6 +34,11 @@ Required:
 
 Optional:
 
+* `command` (string) - The command to invoke ansible. Defaults to "ansible-playbook".
+
+* `extra_arguments` (array of strings) - An array of extra arguments to pass to the
+  ansible command. By default, this is empty.
+
 * `playbook_paths` (array of strings) - An array of paths to playbook files on
   your local system. These will be uploaded to the remote machine under
   `staging_directory`/playbooks. By default, this is empty.


### PR DESCRIPTION
this PR is now two commits:
- e41f620 allows users to provide a replacement command and / or extra args to the `ansible-local` Provisioner. this can be useful, for example, to unbuffer output when using the `docker` Builder, or to modify ansible behavior, like enabling verbose mode, injecting variables, or changing paths.
- f16ba10 is a fixed, squashed version of #834. it allows users to specify directories for group and host vars to be uploaded as well before ansible-playbooks is invoked.

proposed upstream at mitchellh/packer#842, merging now because i need to be able to deploy this.
